### PR TITLE
browserify friendly

### DIFF
--- a/bcrypt-speed.js
+++ b/bcrypt-speed.js
@@ -25,75 +25,103 @@ var bcryptNodejs = require('bcrypt-nodejs');
 var twinBcrypt = require('twin-bcrypt');
 var bcryptjs = require('bcryptjs');
 var bcrypt = require('bcrypt');
+var async = require('async');
 
-var maxDuration = Number(process.argv[2]) || 100;
+var maxDuration = Number(process.argv[2]) || 500;
 console.log('test duration per number of rounds, up to ' + maxDuration + 'ms');
 
 var start, duration, salt, hash, rounds;
 
+var tests = [];
+
+tests.push(idle, testBcryptNodejs)
+tests.push(idle, testTwinBcrypt)
+tests.push(idle, testBcryptjs)
+if (!process.browser) tests.push(idle, testBcrypt)
+
+async.series(tests);
+
 /////////////////////////////////////////////////////////////////////
 // bcrypt-nodejs
-rounds = 3;
+function testBcryptNodejs(callback){
 
-console.log('\nbcrypt-nodejs (pure js, no deps)');
-console.log('rounds', ' ms');
+  rounds = 3;
 
-do {
-  rounds++;
-  salt = bcryptNodejs.genSaltSync(rounds);
-  start = new Date();
-  hash = bcryptNodejs.hashSync('somepass', salt);
-  duration = new Date() - start.getTime();
-  console.log(('   ' + rounds).slice(-3), ('     ' + duration).slice(-6));
-} while (duration < maxDuration);
+  console.log('\nbcrypt-nodejs (pure js, no deps)');
+  console.log('rounds', ' ms');
 
+  do {
+    rounds++;
+    salt = bcryptNodejs.genSaltSync(rounds);
+    start = new Date();
+    hash = bcryptNodejs.hashSync('somepass', salt);
+    duration = new Date() - start.getTime();
+    console.log(('   ' + rounds).slice(-3), ('     ' + duration).slice(-6));
+  } while (duration < maxDuration);
 
+  callback()
+}
 /////////////////////////////////////////////////////////////////////
 // twin-bcrypt
-rounds = 3;
+function testTwinBcrypt(callback){
 
-console.log('\ntwin-bcrypt (pure js, no deps, asm.js)');
-console.log('rounds', ' ms');
+  rounds = 3;
 
-do {
-  rounds++;
-  salt = twinBcrypt.genSalt(rounds);
-  start = new Date();
-  hash = twinBcrypt.hashSync('somepass', salt);
-  duration = new Date() - start.getTime();
-  console.log(('   ' + rounds).slice(-3), ('     ' + duration).slice(-6));
-} while (duration < maxDuration);
+  console.log('\ntwin-bcrypt (pure js, no deps, asm.js)');
+  console.log('rounds', ' ms');
 
+  do {
+    rounds++;
+    salt = twinBcrypt.genSalt(rounds);
+    start = new Date();
+    hash = twinBcrypt.hashSync('somepass', salt);
+    duration = new Date() - start.getTime();
+    console.log(('   ' + rounds).slice(-3), ('     ' + duration).slice(-6));
+  } while (duration < maxDuration);
 
+  callback()
+}
 /////////////////////////////////////////////////////////////////////
 // bcryptjs
-rounds = 3;
+function testBcryptjs(callback){
 
-console.log('\nbcryptjs (pure js, no deps)');
-console.log('rounds', ' ms');
+  rounds = 3;
 
-do {
-  rounds++;
-  salt = bcryptjs.genSaltSync(rounds);
-  start = new Date();
-  hash = bcryptjs.hashSync('somepass', salt);
-  duration = new Date() - start.getTime();
-  console.log(('   ' + rounds).slice(-3), ('     ' + duration).slice(-6));
-} while (duration < maxDuration);
+  console.log('\nbcryptjs (pure js, no deps)');
+  console.log('rounds', ' ms');
 
+  do {
+    rounds++;
+    salt = bcryptjs.genSaltSync(rounds);
+    start = new Date();
+    hash = bcryptjs.hashSync('somepass', salt);
+    duration = new Date() - start.getTime();
+    console.log(('   ' + rounds).slice(-3), ('     ' + duration).slice(-6));
+  } while (duration < maxDuration);
 
+  callback()
+}
 /////////////////////////////////////////////////////////////////////
 // bcrypt
-rounds = 3;
+function testBcrypt(callback){
 
-console.log('\nbcrypt (c++, has deps)');
-console.log('rounds', ' ms');
+  rounds = 3;
 
-do {
-  rounds++;
-  salt = bcrypt.genSaltSync(rounds);
-  start = new Date();
-  hash = bcrypt.hashSync('somepass', salt);
-  duration = new Date() - start.getTime();
-  console.log(('   ' + rounds).slice(-3), ('     ' + duration).slice(-6));
-} while (duration < maxDuration);
+  console.log('\nbcrypt (c++, has deps)');
+  console.log('rounds', ' ms');
+
+  do {
+    rounds++;
+    salt = bcrypt.genSaltSync(rounds);
+    start = new Date();
+    hash = bcrypt.hashSync('somepass', salt);
+    duration = new Date() - start.getTime();
+    console.log(('   ' + rounds).slice(-3), ('     ' + duration).slice(-6));
+  } while (duration < maxDuration);
+
+  callback()
+}
+
+function idle(callback) {
+  setTimeout(callback, 200)
+}

--- a/package.json
+++ b/package.json
@@ -16,14 +16,18 @@
   ],
   "bugs": "https://github.com/timkuijsten/node-bcrypt-speed/issues",
   "dependencies": {
+    "async": "^0.9.0",
+    "bcrypt": ">=0.8.0",
     "bcrypt-nodejs": ">=0.0.3",
-    "twin-bcrypt": ">=2.0.2",
     "bcryptjs": ">=2.0.2",
-    "bcrypt": ">=0.8.0"
+    "twin-bcrypt": ">=2.0.2"
   },
   "bin": "./bcrypt-speed.js",
   "scripts": {
     "start": "node bcrypt-speed.js"
+  },
+  "browser": {
+    "bcrypt": false
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
made a few changes, don't feel the need to merge them.

the idling did not seem to affect performance like i imagined it might.

everyone's pretty close in Chrome Version 40.0.2214.115 (64-bit)

``` js
test duration per number of rounds, up to 500ms

bcrypt-nodejs (pure js, no deps)
 rounds  ms
   4     27
   5     41
   6     75
   7    145
   8    275
   9    551

twin-bcrypt (pure js, no deps, asm.js)
 rounds  ms
   4     20
   5     36
   6     70
   7    142
   8    283
   9    568

bcryptjs (pure js, no deps)
 rounds  ms
   4     18
   5     35
   6     68
   7    137
   8    283
   9    548
```

compare to node v0.10.35, cpp is clear winner

```
test duration per number of rounds, up to 500ms

bcrypt-nodejs (pure js, no deps)
rounds  ms
  4      7
  5     11
  6     20
  7     37
  8     55
  9    109
 10    223
 11    439
 12    868

twin-bcrypt (pure js, no deps, asm.js)
rounds  ms
  4     10
  5      7
  6     13
  7     25
  8     46
  9     93
 10    180
 11    357
 12    722

bcryptjs (pure js, no deps)
rounds  ms
  4      8
  5      9
  6     16
  7     32
  8     58
  9    111
 10    220
 11    441
 12    890

bcrypt (c++, has deps)
rounds  ms
  4      2
  5      3
  6      5
  7      9
  8     18
  9     35
 10     72
 11    142
 12    286
 13    579
```
